### PR TITLE
:+1: searchbox use debounce.

### DIFF
--- a/front/src/applications/hooks/debounce.ts
+++ b/front/src/applications/hooks/debounce.ts
@@ -1,0 +1,24 @@
+import { useRef, useCallback } from 'react';
+
+export const useDebounce = <T>(
+  callback: (arg: T) => void,
+  delay: number
+): [((arg: T) => void)] => {
+  const timer = useRef<NodeJS.Timeout>();
+  const clearDebounce = useCallback(() => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = undefined;
+    }
+  }, []);
+  const debounce = useCallback(
+    (arg: T) => {
+      clearDebounce();
+      timer.current = setTimeout(() => {
+        callback(arg)
+      }, delay);
+    },
+    [callback, clearDebounce, delay]
+  );
+  return [debounce];
+};

--- a/front/src/components/ItemSearch.tsx
+++ b/front/src/components/ItemSearch.tsx
@@ -1,13 +1,17 @@
 import { FC, useState } from "react";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
+import { useDebounce } from "../applications/hooks/debounce";
 
 type Props = {
   onSearchItem: (keyword: string) => Promise<void>;
 };
 
+const INPUT_DELAY = 300;
+
 const ItemSearch: FC<Props> = ({ onSearchItem }) => {
   const [keyword, setKeyword] = useState("");
+  const [debouncedSearchItem] = useDebounce(onSearchItem, INPUT_DELAY);
 
   return (
     <Box>
@@ -19,7 +23,7 @@ const ItemSearch: FC<Props> = ({ onSearchItem }) => {
         fullWidth
         onChange={(e) => {
           setKeyword(e.target.value);
-          onSearchItem(e.target.value);
+          debouncedSearchItem(e.target.value);
         }}
       />
     </Box>


### PR DESCRIPTION
## 課題

> 現状の作りだと検索ボックスで1文字打つごとに検索が実行されていますが、  
> クエリが頻繁に投げられるためパフォーマンスに今後影響する可能性があります。  
> こちらを何度もクエリを投げないように改善してください。

## 修正方針

様々な方法があるが今回は一般的な `debounce` を導入する。
連続して入力され続けている場合はリクエストをキャンセルし続け、最後の入力を待ってリクエストを発行する。

`debounce` の実装は `setTimeout` を用いるが、https://www.gaji.jp/blog/2022/02/09/9097/ にて良きアイディアに恵まれたため、これを拝借した。
今回の課題では `clearDebounce` を戻り値にする必要はなかったため、その部分は削除している。