### PR TITLE
:bug: when item add clear search and result.

### DIFF
--- a/front/src/components/ItemSearch.tsx
+++ b/front/src/components/ItemSearch.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { useState, forwardRef, useImperativeHandle } from "react";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 
@@ -6,8 +6,16 @@ type Props = {
   onSearchItem: (keyword: string) => Promise<void>;
 };
 
-const ItemSearch: FC<Props> = ({ onSearchItem }) => {
+export type Ref = {
+  clear: () => void;
+};
+
+const ItemSearch = forwardRef<Ref, Props>(({ onSearchItem }, ref) => {
   const [keyword, setKeyword] = useState("");
+
+  useImperativeHandle(ref, () => ({
+    clear: () => setKeyword(""),
+  }));
 
   return (
     <Box>
@@ -24,6 +32,6 @@ const ItemSearch: FC<Props> = ({ onSearchItem }) => {
       />
     </Box>
   );
-};
+});
 
 export default ItemSearch;

--- a/front/src/pages/Index.tsx
+++ b/front/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useEffect, useState, useRef } from "react";
 import { Theme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import createStyles from "@mui/styles/createStyles";
@@ -7,7 +7,7 @@ import Grid from "@mui/material/Grid";
 import { ItemVO } from "../types/vo";
 import ItemList from "../components/ItemList";
 import ItemForm from "../components/ItemForm";
-import ItemSearch from "../components/ItemSearch";
+import { default as ItemSearch, Ref as ItemSearchRef } from "../components/ItemSearch";
 import { TodoStore } from "../stores/todo-store";
 import { useSnackbar } from "notistack";
 import { TODO_MAX_LIMIT } from "../types/const";
@@ -24,7 +24,8 @@ const Index: FC<Props> = () => {
   const styles = useStyles();
   const { enqueueSnackbar } = useSnackbar();
   const todoStore = TodoStore.useContainer();
-
+  
+  const search = useRef<ItemSearchRef | null>(null);
   const [items, setItems] = useState<ItemVO[]>([]);
 
   useEffect(() => {
@@ -43,7 +44,8 @@ const Index: FC<Props> = () => {
       isDone: false,
     });
     if (item) {
-      setItems([...items, item]);
+      setItems(await todoStore.loadItems());
+      if (search.current) search.current.clear();
     } else {
       enqueueSnackbar("TODOの追加に失敗しました");
     }
@@ -101,7 +103,7 @@ const Index: FC<Props> = () => {
             <ItemForm onAddItem={onAddItem} />
           </Box>
           <Box>
-            <ItemSearch onSearchItem={onSearchItem} />
+            <ItemSearch ref={search} onSearchItem={onSearchItem} />
           </Box>
           <Box>
             <ItemList


### PR DESCRIPTION
## 課題

> 検索実行 -> そのまま新規TODOを追加 すると  
> 検索ワードと画面の表示状態が噛み合わず不自然な状態が生まれています。  
> こちらを改善してください。要望としては以下です。
>   - 追加したTODOは追加されたことが確認できるように、追加後すぐに画面に出てほしい
>   - 検索ワードはリセットされて、表示も元の状態に戻っても構わない

## 修正方針

- アイテム追加した際にアイテムを全件ロードし直す。
- アイテム追加した際に `ItemSearch` コンポーネントに働きかけ、テキストボックスを空にする。